### PR TITLE
link accessibility commit

### DIFF
--- a/extensions/microsoft-employee-experience/src/Link/Link.tsx
+++ b/extensions/microsoft-employee-experience/src/Link/Link.tsx
@@ -8,7 +8,7 @@ import { ILinkProps } from './Link.types';
 import { shouldUseAnchorTag } from './Link.utils';
 
 export function Link(props: React.PropsWithChildren<ILinkProps>): React.ReactElement {
-  const { to, children, activeStyle, exact, title, className, target, activeClassName, disabled, refresh } = props;
+  const { to, children, activeStyle, exact, title, className, target, activeClassName, disabled, refresh, role, ariaLabel, onClick, } = props;
   const { telemetryClient } = React.useContext(Context as React.Context<IEmployeeExperienceContext>);
   const href = to || '/';
 
@@ -25,6 +25,9 @@ export function Link(props: React.PropsWithChildren<ILinkProps>): React.ReactEle
       properties: { to, title },
       ...(props.logCustomProperties?.() || {}),
     });
+    if (onClick) {
+      onClick();
+    }
   };
 
   if (shouldUseAnchorTag(href, refresh))
@@ -37,6 +40,8 @@ export function Link(props: React.PropsWithChildren<ILinkProps>): React.ReactEle
         title={title}
         className={className}
         disabled={disabled}
+        aria-label={ariaLabel}
+        role={role}
       >
         {children}
       </FluentLink>
@@ -56,6 +61,8 @@ export function Link(props: React.PropsWithChildren<ILinkProps>): React.ReactEle
       className={className}
       activeClassName={activeClassName}
       disabled={disabled}
+      aria-label={props['aria-label']}
+      role={role}
     >
       {children}
     </FluentLink>

--- a/extensions/microsoft-employee-experience/src/Link/Link.types.ts
+++ b/extensions/microsoft-employee-experience/src/Link/Link.types.ts
@@ -1,6 +1,9 @@
 import { UsageFeatureProps } from '../UsageTelemetry';
+import * as React from 'react';
 
-export interface ILinkProps {
+export interface ILinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement | HTMLButtonElement | HTMLElement>,
+    Omit<React.ButtonHTMLAttributes<HTMLAnchorElement | HTMLButtonElement | HTMLElement>, 'type'>,
+    React.RefAttributes<HTMLElement> {
   to: string;
   title: string;
   exact?: boolean;
@@ -15,4 +18,6 @@ export interface ILinkProps {
   logCustomProperties?: () => {
     [key: string]: unknown;
   };
+  ariaLabel: string;
+  onClick: () => void;
 }


### PR DESCRIPTION
For the click tracking Link, while we are using in our application we missed some of the props like aria-lable, role, onClick wich in turn caused accessibility bugs in our app, so we have used the committed code in our app to mitigate the same and doing the same as this can be used as the node module 